### PR TITLE
Fix MGF issues

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,6 +30,7 @@ my %WriteMakefileArgs = (
   },
   "TEST_REQUIRES" => {
     "Crypt::OpenSSL::Guess" => 0,
+    "CryptX" => 0,
     "Exporter" => 0,
     "File::Slurper" => 0,
     "File::Which" => 0,
@@ -53,6 +54,7 @@ my %FallbackPrereqs = (
   "Crypt::OpenSSL::X509" => 0,
   "Crypt::PK::RSA" => 0,
   "Crypt::PRNG" => 0,
+  "CryptX" => 0,
   "Exporter" => 0,
   "File::Slurper" => 0,
   "File::Which" => 0,

--- a/README
+++ b/README
@@ -103,6 +103,37 @@ METHODS
 
         *   mgf1sha512 <http://www.w3.org/2009/xmlenc11#mgf1sha512>
 
+    oaep_params
+        Specify the OAEPparams value to use as part of the mask generation
+        function (MGF). It is optional but can be a specified for rsa-oaep
+        and rsa-oaep-mgf1p EncryptionMethods.
+
+        It is base64 encoded and stored in the XML as OAEPparams.
+
+        If specified you MAY specify the oaep_label_hash that should be
+        used. You should note that not all implementations support an
+        oaep_label_hash that differs from that of the MGF secified in the
+        xenc11:MGF element or the default MGF1 with SHA1.
+
+        The oaep_label_hash is stored in the DigestMethod child element of
+        the EncryptionMethod.
+
+    oaep_label_hash
+        Specify the Hash Algorithm to use for the rsa-oaep Label. Supported
+        algorithms are:
+
+        The default is sha1.
+
+        *   sha1 <http://www.w3.org/2000/09/xmldsig#sha1>
+
+        *   sha224 <http://www.w3.org/2001/04/xmldsig-more#sha224>
+
+        *   sha256 <http://www.w3.org/2001/04/xmlenc#sha256>
+
+        *   sha384 <http://www.w3.org/2001/04/xmldsig-more#sha384>
+
+        *   sha512 <http://www.w3.org/2001/04/xmlenc#sha512>
+
   decrypt( ... )
     Main decryption function.
 

--- a/cpanfile
+++ b/cpanfile
@@ -15,6 +15,7 @@ requires "warnings" => "0";
 
 on 'test' => sub {
   requires "Crypt::OpenSSL::Guess" => "0";
+  requires "CryptX" => "0";
   requires "Exporter" => "0";
   requires "File::Slurper" => "0";
   requires "File::Which" => "0";

--- a/t/06-test-encryption-methods.t
+++ b/t/06-test-encryption-methods.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 126;
+use Test::More tests => 896;
 use Test::Lib;
 use Test::XML::Enc;
 use XML::Enc;
@@ -15,10 +15,12 @@ XML
 
 my @key_methods     = qw/rsa-1_5 rsa-oaep-mgf1p/;
 my @data_methods    = qw/aes128-cbc aes192-cbc aes256-cbc tripledes-cbc aes128-gcm aes192-gcm aes256-gcm/;
-my @oaep_mgf_algs   = qw/mgf1sha1 mgf1sha224 mgf1sha256 mgf1sha384 mgf1sha512/;
+my @oaep_mgf_algs   = qw/rsa-oaep-mgf1p mgf1sha1 mgf1sha224 mgf1sha256 mgf1sha384 mgf1sha512/;
+my @oaep_label_hashes    = qw/sha1 sha224 sha256 sha384 sha512/;
 
 my $xmlsec = get_xmlsec_features();
 my $lax_key_search = $xmlsec->{lax_key_search} ? '--lax-key-search': '';
+my $cryptx = get_cryptx_features();
 
 foreach my $km (@key_methods) {
     foreach my $dm (@data_methods) {
@@ -39,10 +41,6 @@ foreach my $km (@key_methods) {
 
         SKIP: {
             skip "xmlsec1 not installed", 2 unless $xmlsec->{installed};
-            my $version;
-            if (`xmlsec1 version` =~ m/(\d+\.\d+\.\d+)/) {
-                $version = $1;
-            };
             skip "xmlsec version 1.2.27 minimum for GCM", 2 if ! $xmlsec->{aes_gcm};
             ok( open XML, '>', 'tmp.xml' );
             print XML $encrypted;
@@ -56,22 +54,45 @@ foreach my $km (@key_methods) {
 }
 
 foreach my $om (@oaep_mgf_algs) {
-    foreach my $dm (@data_methods) {
-        my $encrypter = XML::Enc->new(
-            {
-                key                 => 't/sign-private.pem',
-                cert                => 't/sign-certonly.pem',
-                data_enc_method     => $dm,
-                key_transport       => 'rsa-oaep',
-                oaep_mgf_alg        => $om,
-                no_xml_declaration  => 1
+    foreach my $omdig (@oaep_label_hashes) {
+        SKIP: {
+            if (! $cryptx->{oaem_mgf_digest} && ($om ne $omdig)) {
+                my $skip = (scalar @data_methods) * 4;
+                skip "CryptX $cryptx->{version} does not support rsa-oaep MGF: $om and digest $omdig", $skip;
             }
-        );
 
-        my $encrypted = $encrypter->encrypt($xml);
-        ok($encrypted  =~ /EncryptedData/, "Successfully Encrypted: Key Method 'rsa-oaep' with $om Data Method $dm");
+            my $km = ( $om eq 'rsa-oaep-mgf1p') ? 'rsa-oaep-mgf1p' : 'rsa-oaep';
+            foreach my $dm (@data_methods) {
+                my $encrypter = XML::Enc->new(
+                    {
+                        key                 => 't/sign-private.pem',
+                        cert                => 't/sign-certonly.pem',
+                        data_enc_method     => $dm,
+                        key_transport       => $km,
+                        oaep_mgf_alg        => $om,
+                        oaep_label_hash     => $omdig,
+                        oaep_params         => 'encrypt',
+                        no_xml_declaration  => 1,
+                    }
+                );
 
-        ok($encrypter->decrypt($encrypted) =~ /XML-SIG_1/, "Successfully Decrypted with XML::Enc");
+                my $encrypted = $encrypter->encrypt($xml);
+                ok($encrypted  =~ /EncryptedData/, "Successful Encrypted: Key Method:$km MGF:$om, param:$omdig Data Method:$dm");
+
+                SKIP: {
+                    skip "xmlsec1 not installed", 2 unless $xmlsec->{installed};
+                    skip "xmlsec version 1.2.27 minimum for GCM", 2 if ! $xmlsec->{aes_gcm};
+                    ok( open XML, '>', "$km-$omdig-$dm-tmp.xml" );
+                    print XML $encrypted;
+                    close XML;
+                    my $verify_response = `xmlsec1 --decrypt $lax_key_search --privkey-pem t/sign-private.pem  $km-$omdig-$dm-tmp.xml 2>&1`;
+                    ok( $verify_response =~ m/XML-SIG_1/, "Successfully decrypted with xmlsec1" )
+                        or warn "calling xmlsec1 failed: '$verify_response'\n";
+                    unlink "$km-$omdig-$dm-tmp.xml";
+                }
+                ok($encrypter->decrypt($encrypted) =~ /XML-SIG_1/, "Successfully Decrypted with XML::Enc");
+            }
+        }
     }
 }
 done_testing;

--- a/t/lib/Test/XML/Enc/Util.pm
+++ b/t/lib/Test/XML/Enc/Util.pm
@@ -9,6 +9,7 @@ our @ISA    = qw(Exporter);
 our @EXPORT = qw(
     get_xmlsec_features
     get_openssl_features
+    get_cryptx_features
  );
 
 our @EXPORT_OK;
@@ -85,6 +86,35 @@ sub get_openssl_features {
                     ripemd160   => ($major eq '3.0' and ($minor >= 0) and ($minor <= 7)) ? 0 : 1,
                 );
     return \%openssl;
+}
+
+#########################################################################
+# get_cryptx_features
+#
+# Parameter:    none
+#
+# Returns a hash of the version and any features that are needed
+# if proper the version is installed
+#
+# Response: hash
+#
+#       %features = (
+#                   version         => '0.077',
+#                   oaem_mgf_digest => 0,
+#       );
+##########################################################################
+sub get_cryptx_features {
+
+    require CryptX;
+
+    my $version = $CryptX::VERSION;
+
+    my %cryptx = (
+                    version         => $version,
+                    oaem_mgf_digest => ($version gt '0.077') ? 1 : 0,
+                );
+
+    return \%cryptx;
 }
 
 1;


### PR DESCRIPTION
libtom (CryptX <= 0.077) does not support specifying the a MGF and OEAPparam digest that differ.

This sorts out most of the issues.  Thinking now I suspect that it will still allow you to generate XML that will not properly decrypt but basically, the two must use the same hash in both